### PR TITLE
cocoapods step will now update pods

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -260,7 +260,7 @@ platform :ios do
     unless workspace.nil? 
       project = nil
       UI.message "Installing Cocoapods"    
-      cocoapods # I mean this is why you're using a workspace, right?
+      cocoapods(repo_update: true) # I mean this is why you're using a workspace, right?
     end
 
     ipa_path = gym(


### PR DESCRIPTION
Hey @chriscombs 

A small change so the Fastlane cocoapods step now updates the pod repo before running.

Maybe this should be configurable in the `.yml` file but for now it is done always. 