### PR TITLE
Revert "Using the correct variable now"

### DIFF
--- a/versions/0.1/Fastfile
+++ b/versions/0.1/Fastfile
@@ -329,7 +329,7 @@ platform :ios do
       'hockey_app_id' => options['hockey-app-id'],
       'changelog' => ENV['COMMIT_CHANGELOG'],
       'team_name' => get_team_name(provisioning_profile_path),
-      'team_id' => team_id,
+      'team_id' => options["team_id"],
       'itc_provider' => options["itc_provider"],
       'scheme' => options['scheme'],
       'configuration' => options['configuration'],


### PR DESCRIPTION
Reverts nodes-ios/bitrise-step-nodes-custom-script#5

Doesnt seem to use the correct team id